### PR TITLE
reduce load on Cirrus-CI API

### DIFF
--- a/.github/workflows/bitcoin-bitcoin-tasks.yml
+++ b/.github/workflows/bitcoin-bitcoin-tasks.yml
@@ -3,7 +3,7 @@
 name: bitcoin-bitcoin-tasks
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '13 3,15 * * *'
   workflow_dispatch:
 concurrency:
   group: "fetch"
@@ -28,7 +28,7 @@ jobs:
     - name: Install python dependecies
       run: pip install requests
     - name: Fetch tasks
-      run: python3 fetch.py --builds 400 --owner bitcoin --repository bitcoin
+      run: python3 fetch.py --builds 200 --owner bitcoin --repository bitcoin
     - name: Commit changes
       run: |
         git add tasks.json graph.json


### PR DESCRIPTION
The task fetch job is failing from time to time with the Cirrus API returning an error - probably related to a timeout. To work around, request only halve the number of builds, but now twice a day at 03:13 and 15:13 UTC.